### PR TITLE
Start servers upon application startup

### DIFF
--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -29,6 +29,4 @@ start() ->
   application:start(ranch),
   application:start(cowboy),
   application:start(hottub),
-  application:start(erldns),
-
-  erldns_events:notify(start_servers).
+  application:start(erldns).

--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -43,6 +43,9 @@ start_phase(post_start, _StartType, _PhaseArgs) ->
   lager:info("Loading zones from local file"),
   erldns_zone_loader:load_zones(),
 
+  lager:info("Notifying servers to start"),
+  erldns_events:notify(start_servers),
+
   ok.
 
 stop(_State) ->


### PR DESCRIPTION
This change notifies the servers to enter service when application startup is complete, instead of only when erldns:start/0 has been used to bring erldns online.
