### PR TITLE
Handle TCP error when getting the socket peername.

### DIFF
--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -58,6 +58,11 @@ setup_metrics() ->
   folsom_metrics:new_meter(udp_request_meter),
   folsom_metrics:new_meter(tcp_request_meter),
 
+  folsom_metrics:new_meter(udp_error_meter),
+  folsom_metrics:new_meter(tcp_error_meter),
+  folsom_metrics:new_history(udp_error_history),
+  folsom_metrics:new_history(tcp_error_history),
+
   folsom_metrics:new_histogram(udp_handoff_histogram),
   folsom_metrics:new_histogram(tcp_handoff_histogram),
 

--- a/src/erldns_event_handler.erl
+++ b/src/erldns_event_handler.erl
@@ -54,6 +54,16 @@ handle_event({end_tcp, [{host, _Host}]}, State) ->
   folsom_metrics:notify({tcp_request_counter, {inc, 1}}),
   {ok, State};
 
+handle_event({udp_error, Reason}, State) ->
+  folsom_metrics:notify({udp_error_meter, 1}),
+  folsom_metrics:notify({udp_error_history, Reason}),
+  {ok, State};
+
+handle_event({tcp_error, Reason}, State) ->
+  folsom_metrics:notify({tcp_error_meter, 1}),
+  folsom_metrics:notify({tcp_error_history, Reason}),
+  {ok, State};
+
 handle_event(_Event, State) ->
   {ok, State}.
 


### PR DESCRIPTION
Handles error responses from `inet:peername` and tracks them.