### PR TITLE
Support Top-level domains

### DIFF
--- a/priv/test.zones.json
+++ b/priv/test.zones.json
@@ -1640,5 +1640,32 @@
                 }
             }
         ]
+    },
+    {
+      "name": "example",
+      "records": [
+        {
+          "name": "example",
+          "type": "SOA",
+          "data": {
+            "mname": "ns.example",
+            "rname": "postmaster.example",
+            "serial": 2015051220,
+            "refresh": 28800,
+            "retry": 7200,
+            "expire": 604800,
+            "minimum": 86400
+          },
+          "ttl": 120
+        },
+        {
+          "name": "example",
+          "type": "NS",
+          "ttl": 120,
+          "data": {
+            "dname": "ns.example"
+          }
+        }
+      ]
     }
 ]

--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -274,12 +274,16 @@ is_name_in_zone(Name, Zone) ->
 
 find_zone_in_cache(Qname) ->
   Name = normalize_name(Qname),
-  case dns:dname_to_labels(Name) of
-    [] -> {error, zone_not_found};
-    [_] -> {error, zone_not_found};
-    [_|Labels] ->
-      case erldns_storage:select(zones, Name) of
-        [{Name, Zone}] -> {ok, Zone};
+  find_zone_in_cache(Name, dns:dname_to_labels(Name)).
+
+find_zone_in_cache(_Name, []) ->
+  {error, zone_not_found};
+find_zone_in_cache(Name, [_|Labels]) ->
+  case erldns_storage:select(zones, Name) of
+    [{Name, Zone}] -> {ok, Zone};
+    _ ->
+      case Labels of
+        [] -> {error, zone_not_found};
         _ -> find_zone_in_cache(dns:labels_to_dname(Labels))
       end
   end.


### PR DESCRIPTION
The idea is to support querying for a user-defined top-level domain. Currently, I am able to create the top-level domain and associated records but unable to query from clients like `dig`. The use-case is for localized service discovery similar to [Consul](https://www.consul.io/docs/agent/dns.html).                                                                                                                                                 