### PR TITLE
Add udp reuse addr

### DIFF
--- a/src/erldns.app.src
+++ b/src/erldns.app.src
@@ -7,6 +7,7 @@
                   inets,
                   crypto,
                   ssl,
+                  mnesia,
                   observer,
                   bear,
                   folsom,

--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -96,7 +96,8 @@ start(Port, InetFamily) ->
 
 start(Address, Port, InetFamily) ->
   lager:info("Starting UDP server for ~p on address ~p and port ~p", [InetFamily, Address, Port]),
-  case gen_udp:open(Port, [binary, {active, once}, {read_packets, 1000}, {ip, Address}, InetFamily]) of
+  case gen_udp:open(Port, [binary, {active, once}, {reuseaddr, true},
+                           {read_packets, 1000}, {ip, Address}, InetFamily]) of
     {ok, Socket} -> 
       lager:info("UDP server (~p, address: ~p) opened socket: ~p", [InetFamily, Address, Socket]),
       {ok, Socket};
@@ -107,7 +108,8 @@ start(Address, Port, InetFamily) ->
 
 start(Address, Port, InetFamily, SocketOpts) ->
   lager:info("Starting UDP server for ~p on address ~p and port ~p (sockopts: ~p)", [InetFamily, Address, Port, SocketOpts]),
-  case gen_udp:open(Port, [binary, {active, once}, {read_packets, 1000}, {ip, Address}, InetFamily|SocketOpts]) of
+  case gen_udp:open(Port, [{reuseaddr, true}, binary, {active, once},
+                           {read_packets, 1000}, {ip, Address}, InetFamily|SocketOpts]) of
     {ok, Socket} -> 
       lager:info("UDP server (~p, address: ~p) opened socket: ~p", [InetFamily, Address, Socket]),
       {ok, Socket};


### PR DESCRIPTION
Some OS's (solaris for example) require to set `{reuseaddr, true}` on UDP connections when you want to open multiple UDP listeners on the same connection. This PR adds it as a default option to the UDP socket creation.

A change in the app.src snuck in here, it adds mnesia as a dependency (since it is).