### PR TITLE
Add support for delegating zone lookups

### DIFF
--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -25,6 +25,7 @@
          use_root_hints/0
         ]).
 -export([
+         zone_delegates/0,
          zone_server_env/0,
          zone_server_max_processes/0,
          zone_server_protocol/0,
@@ -168,6 +169,9 @@ keyget(Key, Data, Default) ->
 %% Zone server configuration
 %% TODO: remove as zone server client logic has been removed
 
+zone_delegates() ->
+    application:get_env(erldns, zone_delegates, []).
+
 zone_server_env() ->
   {ok, ZoneServerEnv} = application:get_env(erldns, zone_server),
   ZoneServerEnv.
@@ -201,7 +205,6 @@ websocket_path() ->
 
 websocket_url() ->
   atom_to_list(websocket_protocol()) ++ "://" ++ websocket_host() ++ ":" ++ integer_to_list(websocket_port()) ++ websocket_path().
-
 
 %% Storage configuration
 
@@ -243,6 +246,7 @@ get_env_value(Key, Name) ->
     {Key, Value} ->
       Value
   end.
+
 
 get_env(storage) ->
   case application:get_env(erldns, storage) of

--- a/src/erldns_resolver.erl
+++ b/src/erldns_resolver.erl
@@ -20,6 +20,8 @@
 
 -export([resolve/3]).
 
+-callback get_records_by_name(dns:dname()) -> [dns:rr()].
+
 %% @doc Resolve the questions in the message.
 -spec resolve(dns:message(), [dns:rr()], dns:ip()) -> dns:message().
 resolve(Message, AuthorityRecords, Host) ->
@@ -61,7 +63,7 @@ resolve(Message, _Qname, _Qtype, {error, not_authoritative}, _Host, _CnameChain)
 %% An SOA was found, thus we are authoritative and have the zone.
 %% Step 3: Match records
 resolve(Message, Qname, Qtype, Zone, Host, CnameChain) ->
-  resolve(Message, Qname, Qtype, erldns_zone_cache:get_records_by_name(Qname), Host, CnameChain, Zone).
+  resolve(Message, Qname, Qtype, get_records_by_name(Zone, Qname), Host, CnameChain, Zone).
 
 %% There were no exact matches on name, so move to the best-match resolution.
 resolve(Message, Qname, Qtype, _MatchedRecords = [], Host, CnameChain, Zone) ->
@@ -391,12 +393,12 @@ best_match(Qname, Zone) -> best_match(Qname, dns:dname_to_labels(Qname), Zone).
 best_match(_Qname, [], _Zone) -> [];
 best_match(Qname, [_|Rest], Zone) ->
   WildcardName = dns:labels_to_dname([<<"*">>] ++ Rest),
-  best_match(Qname, Rest, Zone,  erldns_zone_cache:get_records_by_name(WildcardName)).
+  best_match(Qname, Rest, Zone,  get_records_by_name(Zone, WildcardName)).
 
 best_match(_Qname, [], _Zone, []) -> [];
 best_match(Qname, Labels, Zone, []) ->
   Name = dns:labels_to_dname(Labels),
-  case erldns_zone_cache:get_records_by_name(Name) of
+  case get_records_by_name(Zone, Name) of
     [] -> best_match(Qname, Labels, Zone);
     Matches -> Matches
   end;
@@ -444,7 +446,7 @@ additional_processing(Message, _Host, _Zone, []) ->
   Message;
 %% There are records with names that require additional processing.
 additional_processing(Message, Host, Zone, Names) ->
-  RRs = lists:flatten(lists:map(fun(Name) -> erldns_zone_cache:get_records_by_name(Name) end, Names)),
+  RRs = lists:flatten(lists:map(fun(Name) -> get_records_by_name(Zone, Name) end, Names)),
   Records = lists:filter(erldns_records:match_types([?DNS_TYPE_A, ?DNS_TYPE_AAAA]), RRs),
   additional_processing(Message, Host, Zone, Names, Records).
 
@@ -474,4 +476,28 @@ check_dnssec(Message, Host, Question) ->
       erldns_events:notify({dnssec_request, Host, Question#dns_query.name});
     false ->
       ok
+  end.
+
+%% returns the record lookup delegation mdule for a zone.
+get_delegate(#zone{name = Name}) ->
+  case lists:keyfind(Name, 1, erldns_config:zone_delegates()) of
+    false -> none;
+    {Name, Delegate} -> {ok, Delegate}
+  end.
+
+
+get_records_by_name(Zone, Qname) ->
+  case erldns_zone_cache:get_records_by_name(Qname) of
+    [] ->
+      get_delegate_records(Zone, Qname);
+    Records ->
+      Records
+  end.
+
+get_delegate_records(Zone, Qname) ->
+  case get_delegate(Zone) of
+    {ok, Delegate} ->
+      Delegate:get_records_by_name(Qname);
+    _ ->
+      []
   end.

--- a/src/print_delegate.erl
+++ b/src/print_delegate.erl
@@ -1,0 +1,6 @@
+-module(print_delegate).
+-behaviour(erldns_resolver).
+-export([get_records_by_name/1]).
+get_records_by_name(Qname) ->
+    io:format("get_records_by_name(~p).~n", [Qname]),
+    [].


### PR DESCRIPTION
Adding support for delegating failed lookups as discussed in #45 

* Delegation can be specified per-zone
* Delegation only happens if there is neither a cached record nor a record in the normal configuration
* Has a low overhead when not used - If no delegates are configured this adds a overhead of: 1 x application:get_env + 1x lists:keyfind([])


