### PR TITLE
Use folsom-project instead of boundary for folsom

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 {deps, [
         {lager, ".*", {git, "git://github.com/basho/lager.git", "HEAD"}},
         {recon, ".*", {git, "git://github.com/ferd/recon.git", {tag, "2.2.1"}}},
-        {folsom, ".*", {git, "git://github.com/boundary/folsom.git", "HEAD"}},
+        {folsom, ".*", {git, "git://github.com/folsom-project/folsom.git", "HEAD"}},
         {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", "HEAD"}},
         {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", "HEAD"}},
         {dns, ".*", {git, "git://github.com/aetrion/dns_erlang.git", "HEAD"}},


### PR DESCRIPTION
boundary/folsom is now unmaintained, use folsom-project/folsom instead.