### PR TITLE
Use maps for named index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: erlang
 otp_release:
-  - 18.2.1
+  - 19.3
 
 script:
   - ./rebar3 compile

--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -17,7 +17,7 @@
     authority = [] :: [dns:rr()],
     record_count = 0 :: non_neg_integer(),
     records = [] :: [dns:rr()],
-    records_by_name ::  dict:dict(binary(), [dns:rr()]) | trimmed,
+    records_by_name ::  #{binary() => [dns:rr()]} | trimmed,
     %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
     %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
     records_by_type :: term(),


### PR DESCRIPTION
I've changed data structure for named index because of performance reasons. `build_named_index/2` was super slow for a zone with thousands of records. Here is a small performance test:

```
$ ./run.sh
> rr("include/erldns.hrl").
> R = #dns_rr{name = <<"s">>, type = 1, ttl = 3600, data = #dns_rrdata_a{ip = {127, 0, 0, 1}}}.
> RR = [ R#dns_rr{name = <<(integer_to_binary(N))/binary, ".p">>} || N <- lists:seq(0, 1000000)].
> Zone = {<<"test">>, <<>>, RR, []}.
> timer:tc(fun () -> erldns_zone_cache:put_zone(Zone) end).
```

I've got 12 minutes for master branch and 11 seconds for my version.