### PR TITLE
Introduce timeouts to provide more control over long-running requests

### DIFF
--- a/src/erldns_app.erl
+++ b/src/erldns_app.erl
@@ -79,6 +79,9 @@ setup_metrics() ->
   folsom_metrics:new_counter(packet_dropped_empty_queue_counter),
   folsom_metrics:new_meter(packet_dropped_empty_queue_meter),
 
+  folsom_metrics:new_counter(worker_timeout_counter),
+  folsom_metrics:new_meter(worker_timeout_meter),
+
   folsom_metrics:new_meter(cache_hit_meter),
   folsom_metrics:new_meter(cache_expired_meter),
   folsom_metrics:new_meter(cache_miss_meter),

--- a/src/erldns_storage_mnesia.erl
+++ b/src/erldns_storage_mnesia.erl
@@ -137,24 +137,14 @@ delete_table(Table) ->
 %% in the table creation.
 -spec delete(Table :: atom(), Key :: term()) -> ok | any().
 delete(zones, Key)->
-  case mnesia:dirty_delete({zones, Key}) of
-    ok ->
-      ok;
-    Error ->
-      {error, Error}
-  end;
+  mnesia:dirty_delete({zones, Key});
 delete(Table, Key)->
   case mnesia:is_transaction() of
     true ->
       Delete = fun() -> mnesia:delete({Table, Key}) end,
       mnesia:activity(transaction, Delete);
     false ->
-      case mnesia:dirty_delete({Table, Key}) of
-        ok ->
-          ok;
-        Error ->
-          {error, Error}
-      end
+      mnesia:dirty_delete({Table, Key})
   end.
 
 

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -71,14 +71,6 @@ gc_registered(ProcessName) ->
 
 %% Callbacks
 init(_Args) ->
-  {ok, AppPools} = application:get_env(erldns, pools),
-  AppPoolSpecs = lists:map(fun({PoolName, WorkerModule, PoolConfig}) ->
-                               Args = [{name, {local, PoolName}},
-                                       {worker_module, WorkerModule}]
-                               ++ PoolConfig,
-                               poolboy:child_spec(PoolName, Args)
-                           end, AppPools),
-
   SysProcs = [
               ?CHILD(erldns_events, worker, []),
               ?CHILD(erldns_zone_cache, worker, []),
@@ -91,4 +83,4 @@ init(_Args) ->
               ?CHILD(sample_custom_handler, worker, [])
              ],
 
-  {ok, {{one_for_one, 20, 10}, SysProcs ++ AppPoolSpecs}}.
+  {ok, {{one_for_one, 20, 10}, SysProcs}}.

--- a/src/erldns_udp_server.erl
+++ b/src/erldns_udp_server.erl
@@ -141,7 +141,7 @@ make_workers(Queue, NumWorkers) ->
 make_workers(Queue, NumWorkers, N) ->
   case N < NumWorkers of
     true ->
-      {ok, WorkerPid} = erldns_worker:start_link([]),
+      {ok, WorkerPid} = erldns_worker:start_link([{udp, N}]),
       make_workers(queue:in(WorkerPid, Queue), NumWorkers, N + 1);
     false ->
       Queue

--- a/src/erldns_worker.erl
+++ b/src/erldns_worker.erl
@@ -76,7 +76,7 @@ code_change(_OldVsn, State, _Extra) ->
   {ok, State}.
 
 %% @doc Handle DNS query that comes in over TCP
--spec handle_tcp_dns_query(gen_tcp:socket(), iodata(), {pid(), term()})  -> ok.
+-spec handle_tcp_dns_query(gen_tcp:socket(), iodata(), {pid(), term()}) -> ok | {error, timeout} | {error, timeout, pid()}.
 handle_tcp_dns_query(Socket, <<_Len:16, Bin/binary>>, {WorkerProcessSup, WorkerProcess}) ->
   case inet:peername(Socket) of
     {ok, {Address, _Port}} ->
@@ -120,7 +120,7 @@ handle_decoded_tcp_message(DecodedMessage, Socket, Address, {WorkerProcessSup, {
 
 
 %% @doc Handle DNS query that comes in over UDP
--spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) -> ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, term()}.
+-spec handle_udp_dns_query(gen_udp:socket(), gen_udp:ip(), inet:port_number(), binary(), {pid(), term()}) -> ok | {error, not_owner | timeout | inet:posix() | atom()} | {error, timeout, pid()}.
 handle_udp_dns_query(Socket, Host, Port, Bin, {WorkerProcessSup, WorkerProcess}) ->
   %lager:debug("handle_udp_dns_query(~p ~p ~p)", [Socket, Host, Port]),
   erldns_events:notify({start_udp, [{host, Host}]}),

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -111,7 +111,6 @@ max_payload_size(Message) ->
 
 simulate_timeout(_, false) -> ok;
 simulate_timeout(DecodedMessage, true) ->
-  % Timeout test code
   [Question] = DecodedMessage#dns_message.questions,
   Name = Question#dns_query.name,
   lager:info("qname: ~p", [Name]),

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -1,0 +1,123 @@
+%% Copyright (c) 2012-2018, Aetrion LLC
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+%% @doc Worker module that processes a single DNS packet.
+-module(erldns_worker_process).
+
+-include_lib("dns/include/dns.hrl").
+-include_lib("parse_xfrm_utils/include/parse_xfrm_utils_if_than_else.hrl").
+
+-behaviour(gen_server).
+
+-export([start_link/1]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3
+        ]).
+
+-define(MAX_PACKET_SIZE, 512).
+-define(REDIRECT_TO_LOOPBACK, false).
+-define(LOOPBACK_DEST, {127, 0, 0, 10}).
+-define(DEST_HOST(Host), ?IF(?REDIRECT_TO_LOOPBACK, ?LOOPBACK_DEST, Host)).
+-define(SIMULATE_TIMEOUT, false).
+
+-record(state, {}).
+
+start_link(Args) ->
+  gen_server:start_link(?MODULE, Args, []).
+
+init(_Args) ->
+  {ok, #state{}}.
+
+handle_call({process, DecodedMessage, Socket, {tcp, Address}}, _From, State) ->
+  simulate_timeout(DecodedMessage, ?SIMULATE_TIMEOUT),
+  
+  erldns_events:notify({start_handle, tcp, [{host, Address}]}),
+  Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
+  erldns_events:notify({end_handle, tcp, [{host, Address}]}),
+  case erldns_encoder:encode_message(Response) of
+    {false, EncodedMessage} ->
+      send_tcp_message(Socket, EncodedMessage);
+    {true, EncodedMessage, Message} when is_record(Message, dns_message) ->
+      send_tcp_message(Socket, EncodedMessage);
+    {false, EncodedMessage, _TsigMac} ->
+      send_tcp_message(Socket, EncodedMessage);
+    {true, EncodedMessage, _TsigMac, _Message} ->
+      send_tcp_message(Socket, EncodedMessage)
+  end,
+  {reply, ok, State}; 
+
+handle_call({process, DecodedMessage, Socket, Port, {udp, Host}}, _From, State) ->
+  simulate_timeout(DecodedMessage, ?SIMULATE_TIMEOUT),
+
+  Response = erldns_handler:handle(DecodedMessage, {udp, Host}),
+  DestHost = ?DEST_HOST(Host),
+
+  case erldns_encoder:encode_message(Response, [{'max_size', max_payload_size(Response)}]) of
+    {false, EncodedMessage} ->
+      %lager:debug("Sending encoded response to ~p", [DestHost]),
+      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+    {true, EncodedMessage, Message} when is_record(Message, dns_message)->
+      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+    {false, EncodedMessage, _TsigMac} ->
+      gen_udp:send(Socket, DestHost, Port, EncodedMessage);
+    {true, EncodedMessage, _TsigMac, _Message} ->
+      gen_udp:send(Socket, DestHost, Port, EncodedMessage)
+  end,
+  {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+  {noreply, State}.
+handle_info(_Info, State) ->
+  {noreply, State}.
+terminate(_Reason, _State) ->
+  ok.
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.
+
+
+%% Internal private functions
+
+send_tcp_message(Socket, EncodedMessage) ->
+  BinLength = byte_size(EncodedMessage),
+  TcpEncodedMessage = <<BinLength:16, EncodedMessage/binary>>,
+  gen_tcp:send(Socket, TcpEncodedMessage).
+
+%% Determine the max payload size by looking for additional
+%% options passed by the client.
+max_payload_size(Message) ->
+  case Message#dns_message.additional of
+    [Opt|_] when is_record(Opt, dns_optrr) ->
+      case Opt#dns_optrr.udp_payload_size of
+        [] -> ?MAX_PACKET_SIZE;
+        _ -> Opt#dns_optrr.udp_payload_size
+      end;
+    _ -> ?MAX_PACKET_SIZE
+  end.
+
+simulate_timeout(_, false) -> ok;
+simulate_timeout(DecodedMessage, true) ->
+  % Timeout test code
+  [Question] = DecodedMessage#dns_message.questions,
+  Name = Question#dns_query.name,
+  lager:info("qname: ~p", [Name]),
+  case Name of
+    <<"www.example.com">> ->
+      timer:sleep(3000);
+    _ ->
+      ok
+  end.

--- a/src/erldns_worker_process.erl
+++ b/src/erldns_worker_process.erl
@@ -33,7 +33,6 @@
 -define(REDIRECT_TO_LOOPBACK, false).
 -define(LOOPBACK_DEST, {127, 0, 0, 10}).
 -define(DEST_HOST(Host), ?IF(?REDIRECT_TO_LOOPBACK, ?LOOPBACK_DEST, Host)).
--define(SIMULATE_TIMEOUT, false).
 
 -record(state, {}).
 
@@ -44,7 +43,9 @@ init(_Args) ->
   {ok, #state{}}.
 
 handle_call({process, DecodedMessage, Socket, {tcp, Address}}, _From, State) ->
-  simulate_timeout(DecodedMessage, ?SIMULATE_TIMEOUT),
+  % Uncomment this and the function implementation to simulate a timeout when
+  % querying www.example.com with the test zones
+  % simulate_timeout(DecodedMessage),  
   
   erldns_events:notify({start_handle, tcp, [{host, Address}]}),
   Response = erldns_handler:handle(DecodedMessage, {tcp, Address}),
@@ -62,7 +63,9 @@ handle_call({process, DecodedMessage, Socket, {tcp, Address}}, _From, State) ->
   {reply, ok, State}; 
 
 handle_call({process, DecodedMessage, Socket, Port, {udp, Host}}, _From, State) ->
-  simulate_timeout(DecodedMessage, ?SIMULATE_TIMEOUT),
+  % Uncomment this and the function implementation to simulate a timeout when
+  % querying www.example.com with the test zones
+  % simulate_timeout(DecodedMessage),
 
   Response = erldns_handler:handle(DecodedMessage, {udp, Host}),
   DestHost = ?DEST_HOST(Host),
@@ -109,14 +112,13 @@ max_payload_size(Message) ->
     _ -> ?MAX_PACKET_SIZE
   end.
 
-simulate_timeout(_, false) -> ok;
-simulate_timeout(DecodedMessage, true) ->
-  [Question] = DecodedMessage#dns_message.questions,
-  Name = Question#dns_query.name,
-  lager:info("qname: ~p", [Name]),
-  case Name of
-    <<"www.example.com">> ->
-      timer:sleep(3000);
-    _ ->
-      ok
-  end.
+%simulate_timeout(DecodedMessage) ->
+  %[Question] = DecodedMessage#dns_message.questions,
+  %Name = Question#dns_query.name,
+  %lager:info("qname: ~p", [Name]),
+  %case Name of
+    %<<"www.example.com">> ->
+      %timer:sleep(3000);
+    %_ ->
+      %ok
+  %end.

--- a/src/erldns_worker_process_sup.erl
+++ b/src/erldns_worker_process_sup.erl
@@ -1,0 +1,32 @@
+%% Copyright (c) 2012-2018, Aetrion LLC
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+%% @doc Supervisor that allows terminate and restart of an erldns_worker_process
+%% that is attached to an erldns_worker.
+-module(erldns_worker_process_sup).
+
+-behavior(supervisor).
+
+-export([start_link/1]).
+
+-export([init/1]).
+
+start_link([WorkerId]) ->
+  % This supervisor is registered without a name. An alternative
+  % if a name is necessary is to create an atom() using the WorkerId
+  % value combined with the module name
+  supervisor:start_link(?MODULE, [WorkerId]).
+
+init(WorkerId) ->
+  {ok, {{one_for_one, 20, 10}, [{{WorkerId, erldns_worker_process}, {erldns_worker_process, start_link, [[]]}, permanent, brutal_kill, worker, [erldns_worker_process]}]}}. 


### PR DESCRIPTION
Previous to this change, a significant number of long-running requests could cause worker mailboxes to become too large to process effectively. With this change workers call worker_process(ers) with a specific timeout, and if the timeout is reached, the worker will terminate the existing worker_process(er) and restart it.