### PR TITLE
Prepare v9.0.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v9.0.0-rc1
+
 ### Removed
 
 - Support for encoding/decoding records of type SPF.


### PR DESCRIPTION
This PR adds a section in CHANGELOG.md with `v9.0.0-rc1` version. After this PR is merged we can create a tag with the release candidate.