### PR TITLE
Fix wrong dot logic around SVCB and HTTPS records in the codec

### DIFF
--- a/src/zones/erldns_zone_encoder.erl
+++ b/src/zones/erldns_zone_encoder.erl
@@ -265,10 +265,10 @@ encode_data(#dns_rrdata_svcb{
     ParamsStr = encode_svcb_params(SvcParams),
     case ParamsStr of
         [] ->
-            erlang:iolist_to_binary(io_lib:format("~w ~s.", [Priority, TargetName]));
+            erlang:iolist_to_binary(io_lib:format("~w ~s", [Priority, TargetName]));
         _ ->
             erlang:iolist_to_binary(
-                io_lib:format("~w ~s.~s", [Priority, TargetName, ParamsStr])
+                io_lib:format("~w ~s~s", [Priority, TargetName, ParamsStr])
             )
     end;
 encode_data(#dns_rrdata_https{


### PR DESCRIPTION
Belongs to #318. For now only fixes the newer SVCB and HTTPS records, as those are the new ones.

## :shipit: Deployment Verification

- [ ] Verify the API receives SVCB and HTTPS records without an extra trailing dot