### PR TITLE
SVCB params should use `null` in the json encoding

### DIFF
--- a/src/zones/erldns_zone_decoder.erl
+++ b/src/zones/erldns_zone_decoder.erl
@@ -795,7 +795,7 @@ parse_svcb_params([{Key, Value} | Rest], Acc) ->
                 Acc#{ParamKey => KeyNums};
             ?DNS_SVCB_PARAM_ALPN when is_list(Value) ->
                 Acc#{ParamKey => Value};
-            ?DNS_SVCB_PARAM_NO_DEFAULT_ALPN when Value =:= <<"none">> orelse Value =:= none ->
+            ?DNS_SVCB_PARAM_NO_DEFAULT_ALPN when Value =:= null ->
                 Acc#{ParamKey => none};
             ?DNS_SVCB_PARAM_PORT when is_integer(Value) ->
                 Acc#{ParamKey => Value};

--- a/test/zones_SUITE.erl
+++ b/test/zones_SUITE.erl
@@ -605,7 +605,7 @@ json_record_https_to_erlang(_) ->
                 ~"target_name" => ~".",
                 ~"svc_params" => #{
                     ~"alpn" => [~"h2", ~"h3"],
-                    ~"no-default-alpn" => <<"none">>
+                    ~"no-default-alpn" => null
                 }
             },
             ~"context" => null


### PR DESCRIPTION
As mentioned by @lokst, `null` is a better representation of an empty value in JSON.

## :shipit: Deployment Verification

- [ ] Verify it works as requested