### PR TITLE
Fix flaky test interference

### DIFF
--- a/test/listeners_SUITE.erl
+++ b/test/listeners_SUITE.erl
@@ -19,6 +19,7 @@ all() ->
         {group, tls},
         build_error_response_tuple_format,
         sched_mon_coverage,
+        udp_load_shedding,
         reset_queues,
         stats
     ].
@@ -47,7 +48,6 @@ groups() ->
             udp_reactivate,
             udp_coverage,
             udp_encoder_failure,
-            udp_load_shedding,
             udp_trailing_garbage_raises_error_returns_correct_answer,
             udp_notimp_raises_error_returns_notimp,
             udp_not_a_question_raises_error_returns_nothing

--- a/test/zones_SUITE.erl
+++ b/test/zones_SUITE.erl
@@ -83,7 +83,6 @@ groups() ->
             json_record_svcb_keynnnn_format,
             json_record_null_data,
             json_record_unsupported_type,
-            json_record_context_filtered,
             encode_meta_to_json,
             encode_decode_svcb,
             encode_decode_https,
@@ -102,6 +101,7 @@ groups() ->
         {codec_sequential, [], [
             custom_decode,
             encode_meta_to_json_dnssec,
+            json_record_context_filtered,
             bad_custom_codecs_module_does_not_exist,
             bad_custom_codecs_module_does_not_export_callbacks
         ]},


### PR DESCRIPTION
Fixes #328

This test was running in parallel with many other tests that could steal scheduler time from it, preventing it from saturating the peer node schedulers.

Ideally we'd want to mock the check the schedulers run but this simple change has made the failure irreproducible locally after over a hundred runs so it's probably enough for now.

## :clipboard: Deployment Pre/Post tasks

N/A

## :shipit: Deployment Verification

- [ ] Run `rebar3 ct --suite=listeners_SUITE` repeatedly without failures.