### PR TITLE
Fix CNAME chain truncation at zonecut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+### Fixed
+
+- CNAME chains terminating at a zonecut no longer drop earlier hops from the answer section. `maybe_add_zonecut_records/5` previously filtered CNAMEs by target name, which removed any CNAME whose target stayed inside the parent zone — breaking multi-hop chains where only the last hop crossed the cut. The filter now keys off the CNAME owner name, preserving every parent-zone CNAME in the chain.
+
 ## v10.5.4
 
 ### Changed

--- a/src/pipes/erldns_resolver.erl
+++ b/src/pipes/erldns_resolver.erl
@@ -158,10 +158,13 @@ maybe_add_zonecut_records(ResultMsg, Zone, QLabels, _, _) ->
         [] ->
             ResultMsg;
         ZonecutRecords ->
+            %% Keep every CNAME whose owner name sits in the parent zone (above the cut),
+            %% so multi-hop chains terminating at a zonecut are preserved intact. Filtering
+            %% by target instead drops earlier hops whose targets stay inside the parent zone.
             FilteredCnameAnswers = lists:filter(
-                fun(#dns_rr{type = RRType, data = Data}) ->
+                fun(#dns_rr{type = RRType, name = Name}) ->
                     ?DNS_TYPE_CNAME =:= RRType andalso
-                        [] =/= detect_zonecut(Zone, AuthLabels, Data#dns_rrdata_cname.dname)
+                        [] =:= detect_zonecut(Zone, AuthLabels, Name)
                 end,
                 ResultMsg#dns_message.answers
             ),

--- a/test/resolver_SUITE.erl
+++ b/test/resolver_SUITE.erl
@@ -15,6 +15,7 @@ all() ->
         resolve_authoritative_host_not_found,
         resolve_authoritative_zone_cut,
         resolve_authoritative_zone_cut_with_cnames,
+        resolve_authoritative_zone_cut_with_cname_chain_through_wildcard,
         resolve_authoritative_self_delegation_trailing_dot_name_mismatch,
         resolve_authoritative_max_depth_returns_servfail
     ].
@@ -96,6 +97,52 @@ resolve_authoritative_zone_cut_with_cnames(_) ->
     ?assertEqual(?DNS_RCODE_NOERROR, A#dns_message.rc),
     ?assertEqual(NSRecord, A#dns_message.authority),
     ?assertEqual(CnameRecords, A#dns_message.answers),
+    erldns_zone_cache:delete_zone(ZoneName).
+
+%% A chain of two CNAMEs in the parent zone where the second hop is matched by a
+%% wildcard and the chain terminates at a delegated subzone. Both CNAMEs must
+%% appear in the ANSWER section in chain order; previously the first hop was
+%% filtered out because maybe_add_zonecut_records keyed the filter off the CNAME
+%% target rather than the CNAME owner name.
+resolve_authoritative_zone_cut_with_cname_chain_through_wildcard(_) ->
+    erldns_zone_cache:start_link(),
+    erldns_handler:start_link(),
+    ZoneName = dns_domain:to_lower(~"chain-zone-cut.example"),
+    Qname = ~"ffog.chain-zone-cut.example",
+    SoaData = #dns_rrdata_soa{
+        mname = ~"ns1.chain-zone-cut.example",
+        rname = ~"admin.chain-zone-cut.example",
+        serial = 1, refresh = 3600, retry = 600, expire = 86400, minimum = 300
+    },
+    SOA = #dns_rr{name = ZoneName, type = ?DNS_TYPE_SOA, ttl = 3600, data = SoaData},
+    Cname1 = #dns_rr{
+        name = Qname, type = ?DNS_TYPE_CNAME, ttl = 3600,
+        data = #dns_rrdata_cname{dname = ~"ffog.client.chain-zone-cut.example"}
+    },
+    WildcardCname = #dns_rr{
+        name = ~"*.client.chain-zone-cut.example", type = ?DNS_TYPE_CNAME, ttl = 60,
+        data = #dns_rrdata_cname{dname = ~"swarm.dyn.chain-zone-cut.example"}
+    },
+    %% The wildcard CNAME is instantiated with the queried owner name per RFC 4592 §3.3.1.
+    ExpandedWildcardCname = WildcardCname#dns_rr{
+        name = ~"ffog.client.chain-zone-cut.example"
+    },
+    DelegationNS = #dns_rr{
+        name = ~"dyn.chain-zone-cut.example", type = ?DNS_TYPE_NS, ttl = 3600,
+        data = #dns_rrdata_ns{dname = ~"ns-ext.example."}
+    },
+    Z = erldns_zone_codec:build_zone(
+        ZoneName, ~"digest", [SOA, Cname1, WildcardCname, DelegationNS], []
+    ),
+    ok = erldns_zone_cache:put_zone(Z),
+    Msg = #dns_message{questions = [#dns_query{name = Qname, type = ?DNS_TYPE_A}]},
+    A = erldns_resolver:resolve_authoritative(
+        Msg, Z, Qname, dns_domain:split(Qname), ?DNS_TYPE_A, [], ?MAX_RESOLUTION_DEPTH
+    ),
+    ?assertEqual(false, A#dns_message.aa),
+    ?assertEqual(?DNS_RCODE_NOERROR, A#dns_message.rc),
+    ?assertEqual([DelegationNS], A#dns_message.authority),
+    ?assertEqual([Cname1, ExpandedWildcardCname], A#dns_message.answers),
     erldns_zone_cache:delete_zone(ZoneName).
 
 %% NS at the same name as the answer (self-delegation) must be detected even when

--- a/test/resolver_SUITE.erl
+++ b/test/resolver_SUITE.erl
@@ -112,15 +112,23 @@ resolve_authoritative_zone_cut_with_cname_chain_through_wildcard(_) ->
     SoaData = #dns_rrdata_soa{
         mname = ~"ns1.chain-zone-cut.example",
         rname = ~"admin.chain-zone-cut.example",
-        serial = 1, refresh = 3600, retry = 600, expire = 86400, minimum = 300
+        serial = 1,
+        refresh = 3600,
+        retry = 600,
+        expire = 86400,
+        minimum = 300
     },
     SOA = #dns_rr{name = ZoneName, type = ?DNS_TYPE_SOA, ttl = 3600, data = SoaData},
     Cname1 = #dns_rr{
-        name = Qname, type = ?DNS_TYPE_CNAME, ttl = 3600,
+        name = Qname,
+        type = ?DNS_TYPE_CNAME,
+        ttl = 3600,
         data = #dns_rrdata_cname{dname = ~"ffog.client.chain-zone-cut.example"}
     },
     WildcardCname = #dns_rr{
-        name = ~"*.client.chain-zone-cut.example", type = ?DNS_TYPE_CNAME, ttl = 60,
+        name = ~"*.client.chain-zone-cut.example",
+        type = ?DNS_TYPE_CNAME,
+        ttl = 60,
         data = #dns_rrdata_cname{dname = ~"swarm.dyn.chain-zone-cut.example"}
     },
     %% The wildcard CNAME is instantiated with the queried owner name per RFC 4592 §3.3.1.
@@ -128,7 +136,9 @@ resolve_authoritative_zone_cut_with_cname_chain_through_wildcard(_) ->
         name = ~"ffog.client.chain-zone-cut.example"
     },
     DelegationNS = #dns_rr{
-        name = ~"dyn.chain-zone-cut.example", type = ?DNS_TYPE_NS, ttl = 3600,
+        name = ~"dyn.chain-zone-cut.example",
+        type = ?DNS_TYPE_NS,
+        ttl = 3600,
         data = #dns_rrdata_ns{dname = ~"ns-ext.example."}
     },
     Z = erldns_zone_codec:build_zone(


### PR DESCRIPTION
When a CNAME chain in the parent zone terminates at a delegated subzone, `maybe_add_zonecut_records/5` was filtering the answer section by the CNAME target, keeping only CNAMEs whose target crossed the zonecut. Any earlier hop whose target stayed inside the parent zone was dropped, leaving a response with no record matching QNAME — malformed per RFC 1034 §3.6.2.

This PR switches the filter to key off the CNAME owner name: keep every CNAME whose owner sits above the cut. The boundary-crossing CNAME still qualifies (its owner is in the parent zone), and any CNAME whose owner sits below the cut continues to be dropped. The semantic predicate has been the same since `b005ce6` (Dec 2018); the bug surfaces only on chains of ≥ 2 parent-zone CNAMEs ending at a delegated subzone, which the existing `resolve_authoritative_zone_cut_with_cnames` test did not cover.

A CT regression test (`resolve_authoritative_zone_cut_with_cname_chain_through_wildcard`) is added alongside the fix.

Fixes https://github.com/dnsimple/erldnsimple/issues/777


## :clipboard: Deployment Pre/Post tasks

N/A


## :shipit: Deployment Verification

- [ ] A query for a name whose CNAME chain in the parent zone terminates at a delegated subzone returns every CNAME in the chain in the ANSWER section, instead of only the boundary-crossing hop.
- [ ] `rebar3 ct --suite test/resolver_SUITE` passes against the deployed version.