### PR TITLE
Add autostart_listeners config + erldns:start_listeners/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v10.6.0
+
+### Added
+
+- `autostart_listeners` application environment (default `true`) and `erldns:start_listeners/0`.
+
+## v10.5.6
+
+### Changed
+
+- Updated dependencies
+
 ## v10.5.5
 
 ### Fixed

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -19,7 +19,7 @@ Convenience API to start erldns directly.
 
 -include("erldns.hrl").
 
--export([start/0]).
+-export([start/0, start_listeners/0]).
 
 -export_type([keyset/0, zone/0]).
 
@@ -29,3 +29,18 @@ Convenience API to start erldns directly.
 -spec start() -> term().
 start() ->
     application:ensure_all_started(erldns).
+
+-doc """
+Start the DNS listeners if they were not started at boot.
+
+When `erldns` is configured with the `autostart_listeners` application environment set to
+`false`, the listeners (and the sockets they bind) are not started during boot. An embedding
+application can then call this once its own resources are ready, so no query is served before
+they exist.
+
+Returns the supervisor child start result. Idempotent: returns `{error, {already_started, _}}`
+when the listeners are already running.
+""".
+-spec start_listeners() -> supervisor:startchild_ret().
+start_listeners() ->
+    erldns_sup:start_listeners().

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -17,7 +17,7 @@
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/0, start_listeners/0]).
 -export([gc/0, gc_registered/0, gc_registered/1]).
 
 -export([init/1]).
@@ -25,6 +25,12 @@
 -spec start_link() -> supervisor:startlink_ret().
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, noargs).
+
+%% Start the DNS listeners on request, for when they were not started at boot
+%% (`autostart_listeners` set to `false`).
+-spec start_listeners() -> supervisor:startchild_ret().
+start_listeners() ->
+    supervisor:start_child(?MODULE, supervisor(erldns_listeners)).
 
 %% Garbage collect all processes.
 -spec gc() -> integer().
@@ -49,10 +55,16 @@ init(_Args) ->
     Children =
         [
             supervisor(erldns_zones),
-            supervisor(erldns_pipeline),
-            supervisor(erldns_listeners)
+            supervisor(erldns_pipeline)
+            | listener_children(application:get_env(erldns, autostart_listeners, true))
         ],
     {ok, {SupFlags, Children}}.
+
+-spec listener_children(boolean()) -> [supervisor:child_spec()].
+listener_children(true) ->
+    [supervisor(erldns_listeners)];
+listener_children(false) ->
+    [].
 
 supervisor(Module) ->
     #{id => Module, start => {Module, start_link, []}, type => supervisor}.

--- a/test/listeners_SUITE.erl
+++ b/test/listeners_SUITE.erl
@@ -21,7 +21,9 @@ all() ->
         sched_mon_coverage,
         udp_load_shedding,
         reset_queues,
-        stats
+        stats,
+        autostart_listeners_gates_init,
+        autostart_listeners_started_on_request
     ].
 
 -spec groups() -> [ct_suite:ct_group_def()].
@@ -118,6 +120,44 @@ name_must_be_atom(_) ->
     ),
     application:set_env(erldns, listeners, [#{name => good_name, port => 0}]),
     ?assertMatch({ok, _}, erldns_listeners:start_link()).
+
+autostart_listeners_gates_init(_) ->
+    % erldns_sup omits the listeners child at boot when autostart_listeners is false.
+    application:unset_env(erldns, autostart_listeners),
+    ?assert(sup_starts_listeners()),
+    application:set_env(erldns, autostart_listeners, false),
+    ?assertNot(sup_starts_listeners()),
+    application:set_env(erldns, autostart_listeners, true),
+    ?assert(sup_starts_listeners()),
+    application:unset_env(erldns, autostart_listeners).
+
+sup_starts_listeners() ->
+    {ok, {_SupFlags, Children}} = erldns_sup:init(noargs),
+    lists:any(fun(#{id := Id}) -> Id =:= erldns_listeners end, Children).
+
+autostart_listeners_started_on_request(Config) ->
+    % With autostart_listeners=false the listeners are not up at boot; start_listeners/0 opens
+    % them and is idempotent.
+    AppConfig = [
+        {erldns, [
+            {autostart_listeners, false},
+            {listeners, [
+                #{
+                    name => ?FUNCTION_NAME,
+                    transport => standard,
+                    port => 0,
+                    opts => #{ingress_request_timeout => ?INGRESS_TIMEOUT}
+                }
+            ]}
+        ]}
+    ],
+    Config1 = app_helper:start_erldns(Config, AppConfig),
+    Node = app_helper:get_node(Config1),
+    ?assertEqual(undefined, erpc:call(Node, erlang, whereis, [erldns_listeners])),
+    ?assertMatch({ok, _}, erpc:call(Node, erldns, start_listeners, [])),
+    ?assert(is_pid(erpc:call(Node, erlang, whereis, [erldns_listeners]))),
+    ?assertMatch({error, {already_started, _}}, erpc:call(Node, erldns, start_listeners, [])),
+    app_helper:stop(Config1).
 
 port_must_be_inet_port(_) ->
     application:set_env(erldns, listeners, [#{name => ?FUNCTION_NAME, port => bad_port}]),


### PR DESCRIPTION
Add an `autostart_listeners` application environment (default `true`) and a public `erldns:start_listeners/0`. When set to `false`, `erldns` boots its zones and pipeline **without binding any listener sockets**; the embedding application calls `erldns:start_listeners/0` once its own resources are ready, so no query is served before they exist.

## :mag: QA

**Scenario: deferred listeners**

- Boot `erldns` with `{autostart_listeners, false}` and a configured listener; confirm `whereis(erldns_listeners) =:= undefined` (no sockets bound).
- Call `erldns:start_listeners/0`; confirm `erldns_listeners` is now running and the configured port answers queries.
- Call it again; confirm it is idempotent (`{error, {already_started, _}}`).
- Boot with the flag unset/`true`; confirm the listeners come up at boot as before.

## :clipboard: Deployment Pre/Post tasks

N/A

## :shipit: Deployment Verification

- [x] no changing behaviour in prod