### PR TITLE
Derive the NSEC next name for QNAMEs at the 255-octet ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v11.1.1
+
+### Fixed
+
+- Compact denial of existence no longer fails for query names at the 255-octet ceiling, implementing the successor ladder of RFC 4471 §3.1.2.
+
 ## v11.1.0
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Compact denial of existence no longer fails for query names at the 255-octet ceiling, implementing the successor ladder of RFC 4471 §3.1.2.
+- Pipeline exception logs now report the reason under `reason`, as every other exception log in the library and as the `m:erldns_pipeline` docs already stated, rather than under `error`.
 
 ## v11.1.0
 

--- a/src/pipes/erldns_dnssec.erl
+++ b/src/pipes/erldns_dnssec.erl
@@ -44,7 +44,7 @@ prepare(Opts) ->
     choose_signer_for_rrset/2,
     find_unique_lookups/1,
     map_nsec_rr_types/3,
-    next_dname/2
+    next_dname/3
 ]).
 -endif.
 
@@ -230,7 +230,7 @@ handle(#dns_message{answers = []} = Msg, Zone, QLabels, QName, QType, Mappers, _
     SoaRRSigRecords = maybe_get_soa_rrsig_records(ApexRRSigRRs, MsgAuths),
     RecordTypesForQname = record_types_for_name(Zone, QLabels),
     NsecRrTypes = map_nsec_rr_types(QType, RecordTypesForQname, Mappers),
-    NextDname = next_dname(QName, QLabels),
+    NextDname = next_dname(QName, QLabels, Zone),
     NsecRecord =
         #dns_rr{
             name = QName,
@@ -351,13 +351,17 @@ map_nsec_rr_types(QType, Types, Mappers) ->
 %% formed by prepending a label holding a single zero octet. That costs two octets on the wire,
 %% which a QNAME sitting at the 255-octet ceiling cannot afford, so fall back to the successor
 %% ladder of RFC 4471 §3.1.2.
--spec next_dname(dns:dname(), dns:labels()) -> dns:dname().
-next_dname(QName, QLabels) ->
+-spec next_dname(dns:dname(), dns:labels(), erldns:zone()) -> dns:dname().
+next_dname(QName, QLabels, #zone{labels = ZLabels, name = ZoneName}) ->
     case name_wire_size(QLabels) of
         Size when Size =< 253 ->
             <<?NEXT_DNAME_PART/binary, ".", QName/binary>>;
         Size ->
-            dns_domain:join(successor_labels(QLabels, Size))
+            Depth = length(QLabels) - length(ZLabels),
+            case successor_labels(QLabels, Size, Depth) of
+                apex -> ZoneName;
+                Labels -> dns_domain:join(Labels)
+            end
     end.
 
 -spec name_wire_size(dns:labels()) -> pos_integer().
@@ -373,20 +377,24 @@ name_wire_size(Labels) ->
 %% is representable. Applying step 2's action here instead yields `bar\000.<rest>', the true
 %% immediate representable successor, keeping the span empty. RFC 4471 is Experimental and predates
 %% RFC 8198 by eleven years.
--spec successor_labels(dns:labels(), pos_integer()) -> dns:labels().
-successor_labels([Label | Rest], Size) ->
+%%
+%% `Depth' is how many labels below the zone apex the name currently sits, and it bounds the
+%% ascent. Growing the left-most label of the apex itself would name a sibling of the zone, and the
+%% Next Domain Name is a name in this zone (RFC 4034 §4.1.1). At the apex, that section's rule for
+%% the last NSEC of a zone applies instead, and the answer is the apex.
+-spec successor_labels(dns:labels(), pos_integer(), pos_integer()) -> dns:labels() | apex.
+successor_labels([Label | Rest], Size, Depth) when 0 < Depth ->
     LabelSize = byte_size(Label),
     case label_successor(Label, LabelSize, Size) of
-        max when Rest =/= [] ->
-            successor_labels(Rest, Size - LabelSize - 1);
+        max when 1 < Depth ->
+            successor_labels(Rest, Size - LabelSize - 1, Depth - 1);
         max ->
-            %% N was the largest representable name: a name of 254 octets or more cannot be built
-            %% out of 63-octet all-0xff labels alone (three reach 193 octets, four exceed 255),
-            %% so one label is always short enough for `label_successor/3' to answer.
-            [];
+            apex;
         Successor when is_binary(Successor) ->
             [Successor | Rest]
-    end.
+    end;
+successor_labels(_, _, _) ->
+    apex.
 
 %% RFC 4471 §3.1.2 steps 2 and 3: grow the label by an octet of the minimum sort value where both
 %% it and the name have the room, otherwise increment it in place. `max' when neither is possible.

--- a/src/pipes/erldns_dnssec.erl
+++ b/src/pipes/erldns_dnssec.erl
@@ -38,8 +38,14 @@ prepare(Opts) ->
 -export([add_nsec_type_mapper/3]).
 
 -ifdef(TEST).
--export([handle/7, requires_key_signing_key/1, choose_signer_for_rrset/2, find_unique_lookups/1]).
--export([map_nsec_rr_types/3]).
+-export([
+    handle/7,
+    requires_key_signing_key/1,
+    choose_signer_for_rrset/2,
+    find_unique_lookups/1,
+    map_nsec_rr_types/3,
+    next_dname/2
+]).
 -endif.
 
 -doc """
@@ -224,7 +230,7 @@ handle(#dns_message{answers = []} = Msg, Zone, QLabels, QName, QType, Mappers, _
     SoaRRSigRecords = maybe_get_soa_rrsig_records(ApexRRSigRRs, MsgAuths),
     RecordTypesForQname = record_types_for_name(Zone, QLabels),
     NsecRrTypes = map_nsec_rr_types(QType, RecordTypesForQname, Mappers),
-    NextDname = <<?NEXT_DNAME_PART/binary, ".", QName/binary>>,
+    NextDname = next_dname(QName, QLabels),
     NsecRecord =
         #dns_rr{
             name = QName,
@@ -340,6 +346,73 @@ map_nsec_rr_types(QType, Types, Mappers) ->
             Types
         )
     ).
+
+%% RFC 9824 §3.1: the NSEC Next Domain Name is the immediate lexicographic successor of the QNAME,
+%% formed by prepending a label holding a single zero octet. That costs two octets on the wire,
+%% which a QNAME sitting at the 255-octet ceiling cannot afford, so fall back to the successor
+%% ladder of RFC 4471 §3.1.2.
+-spec next_dname(dns:dname(), dns:labels()) -> dns:dname().
+next_dname(QName, QLabels) ->
+    case name_wire_size(QLabels) of
+        Size when Size =< 253 ->
+            <<?NEXT_DNAME_PART/binary, ".", QName/binary>>;
+        Size ->
+            dns_domain:join(successor_labels(QLabels, Size))
+    end.
+
+-spec name_wire_size(dns:labels()) -> pos_integer().
+name_wire_size(Labels) ->
+    lists:foldl(fun(Label, Acc) -> Acc + byte_size(Label) + 1 end, 1, Labels).
+
+%% RFC 4471 §3.1.2 steps 2-4: the smallest name sorting after N and after every name below it.
+%%
+%% Step 4 deviates deliberately. The RFC loops back to step 2, whose guard ("N is one octet shorter
+%% than the maximum DNS name length") can no longer hold once a 64-octet label has been dropped, so
+%% the RFC falls through to step 3 and returns a name past the true successor: for
+%% `<0xff x63>.bar.<rest>' it yields `bas.<rest>', though `barx.<rest>' sorts inside that span and
+%% is representable. Applying step 2's action here instead yields `bar\000.<rest>', the true
+%% immediate representable successor, keeping the span empty. RFC 4471 is Experimental and predates
+%% RFC 8198 by eleven years.
+-spec successor_labels(dns:labels(), pos_integer()) -> dns:labels().
+successor_labels([Label | Rest], Size) ->
+    LabelSize = byte_size(Label),
+    case label_successor(Label, LabelSize, Size) of
+        max when Rest =/= [] ->
+            successor_labels(Rest, Size - LabelSize - 1);
+        max ->
+            %% N was the largest representable name: a name of 254 octets or more cannot be built
+            %% out of 63-octet all-0xff labels alone (three reach 193 octets, four exceed 255),
+            %% so one label is always short enough for `label_successor/3' to answer.
+            [];
+        Successor when is_binary(Successor) ->
+            [Successor | Rest]
+    end.
+
+%% RFC 4471 §3.1.2 steps 2 and 3: grow the label by an octet of the minimum sort value where both
+%% it and the name have the room, otherwise increment it in place. `max' when neither is possible.
+-spec label_successor(dns:label(), non_neg_integer(), pos_integer()) -> dns:label() | max.
+label_successor(Label, LabelSize, NameSize) when LabelSize =< 62, NameSize =< 254 ->
+    <<Label/binary, 0>>;
+label_successor(Label, LabelSize, _NameSize) ->
+    increment_label(Label, LabelSize).
+
+%% RFC 4471 §3.1.2 step 3: increment the right-most octet below the maximum sort value and drop
+%% everything to its right. Uppercase US-ASCII is skipped because canonical order compares names
+%% lowercased (RFC 4034 §6.1), so 0x41-0x5a never occur in a canonical name and the successor of
+%% $@ is $[. QName arrives lowercased, so that is the only skip that can arise.
+-spec increment_label(dns:label(), non_neg_integer()) -> dns:label() | max.
+increment_label(_, 0) ->
+    max;
+increment_label(Label, Pos) ->
+    Prev = Pos - 1,
+    case Label of
+        <<_:Prev/binary, 16#ff, _/binary>> ->
+            increment_label(Label, Prev);
+        <<Prefix:Prev/binary, $@, _/binary>> ->
+            <<Prefix/binary, $[>>;
+        <<Prefix:Prev/binary, Octet, _/binary>> ->
+            <<Prefix/binary, (Octet + 1)>>
+    end.
 
 -compile({inline, [minimum_soa_ttl/1]}).
 -spec minimum_soa_ttl(dns:rr()) -> dns:ttl().

--- a/src/pipes/erldns_pipeline.erl
+++ b/src/pipes/erldns_pipeline.erl
@@ -465,7 +465,7 @@ do_call(Msg, [Pipe | Pipes], Opts) when is_function(Pipe, 2) ->
                     dns_message => Msg,
                     opts => Opts,
                     class => Class,
-                    error => Error,
+                    reason => Error,
                     stacktrace => Stacktrace
                 },
                 ?LOG_METADATA
@@ -521,7 +521,7 @@ execute_work(Msg0, Opts0, [AsyncFun0 | Pipes], Retries) ->
                     dns_message => Msg0,
                     opts => Opts0,
                     class => Class,
-                    error => Error,
+                    reason => Error,
                     stacktrace => Stacktrace
                 },
                 ?LOG_METADATA

--- a/test/dnssec_SUITE.erl
+++ b/test/dnssec_SUITE.erl
@@ -5,6 +5,7 @@
 
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("dns_erlang/include/dns.hrl").
+-include_lib("erldns/include/erldns.hrl").
 
 -spec all() -> [ct_suite:ct_test_def()].
 all() ->
@@ -29,6 +30,7 @@ all() ->
         next_dname_increments_leftmost_label_at_255,
         next_dname_skips_uppercase_ascii,
         next_dname_ascends_past_saturated_label,
+        next_dname_stops_at_the_zone_apex,
         nsec_signed_for_max_length_qname
     ].
 
@@ -610,6 +612,19 @@ next_dname_ascends_past_saturated_label(_Config) ->
     ?assertEqual([~"bar\000" | Rest], dns_domain:split(Next)),
     assert_valid_successor(QName, Next).
 
+%% The ascent stops at the zone apex. Growing the apex's own left-most label would name a sibling
+%% of the zone, and the Next Domain Name is a name in this zone (RFC 4034 §4.1.1); that section's
+%% rule for the last NSEC of a zone gives the apex instead. Reachable only for an apex long enough
+%% that one saturated label below it reaches the ceiling, so 190 octets or more.
+next_dname_stops_at_the_zone_apex(_Config) ->
+    Label = fun(Len) -> binary:copy(~"a", Len) end,
+    ZoneName =
+        <<(Label(48))/binary, ".", (Label(63))/binary, ".", (Label(63))/binary, ".example.com">>,
+    ?assertEqual(190, byte_size(dns_domain:to_wire(ZoneName))),
+    QName = <<(binary:copy(<<16#ff>>, 63))/binary, ".", ZoneName/binary>>,
+    ?assertEqual(254, byte_size(dns_domain:to_wire(QName))),
+    ?assertEqual(ZoneName, next_dname(QName, ZoneName)).
+
 %% End to end: the compact denial-of-existence NSEC for a max-length QNAME is built and signed
 %% instead of raising `name_too_long' out of the RRSIG canonicalisation.
 nsec_signed_for_max_length_qname(_Config) ->
@@ -634,8 +649,15 @@ nsec_signed_for_max_length_qname(_Config) ->
     #dns_rr{data = #dns_rrdata_nsec{next_dname = Next}} = Nsec,
     assert_valid_successor(QName, Next).
 
+%% Every name the ladder cases build sits two labels below its zone apex, which is all
+%% `next_dname/3' needs of the zone besides its name.
 next_dname(QName) ->
-    erldns_dnssec:next_dname(QName, dns_domain:split(QName)).
+    Labels = dns_domain:split(QName),
+    next_dname(QName, dns_domain:join(lists:nthtail(length(Labels) - 2, Labels))).
+
+next_dname(QName, ZoneName) ->
+    Zone = #zone{labels = dns_domain:split(ZoneName), name = ZoneName},
+    erldns_dnssec:next_dname(QName, dns_domain:split(QName), Zone).
 
 %% The two invariants every branch of the ladder owes: the successor is encodable at all, which is
 %% what the production crash violated, and it sorts after its input, without which the NSEC would

--- a/test/dnssec_SUITE.erl
+++ b/test/dnssec_SUITE.erl
@@ -23,7 +23,13 @@ all() ->
         test_requires_key_signing_key_function,
         find_rrsigs_deduplicates_by_name_and_type,
         add_nsec_type_mapper_accumulates,
-        map_nsec_rr_types_widens_custom_types
+        map_nsec_rr_types_widens_custom_types,
+        next_dname_prepends_null_label,
+        next_dname_appends_null_octet_at_254,
+        next_dname_increments_leftmost_label_at_255,
+        next_dname_skips_uppercase_ascii,
+        next_dname_ascends_past_saturated_label,
+        nsec_signed_for_max_length_qname
     ].
 
 -spec init_per_suite(ct_suite:ct_config()) -> ct_suite:ct_config().
@@ -550,3 +556,119 @@ map_nsec_rr_types_widens_custom_types(_Config) ->
         [?DNS_TYPE_A, 2, 46],
         erldns_dnssec:map_nsec_rr_types(?DNS_TYPE_A, Types, Mappers)
     ).
+
+%% RFC 4471 §3.1.2 step 1, the case every real query takes: a name with room to spare gets a
+%% leading label of one zero octet.
+next_dname_prepends_null_label(_Config) ->
+    QName = ~"foo.example.com",
+    Next = next_dname(QName),
+    ?assertEqual(~"\000.foo.example.com", Next),
+    assert_valid_successor(QName, Next).
+
+%% RFC 4471 §3.1.2 step 2: at 254 octets the leading label no longer fits, but a zero octet can
+%% still be appended inside the leftmost label for a cost of one.
+next_dname_appends_null_octet_at_254(_Config) ->
+    QName = name_of_wire_size(254, ~"leftmost", ~"example.com"),
+    [Leftmost | Rest] = dns_domain:split(QName),
+    Next = next_dname(QName),
+    ?assertEqual([<<Leftmost/binary, 0>> | Rest], dns_domain:split(Next)),
+    ?assertEqual(255, byte_size(dns_domain:to_wire(Next))),
+    assert_valid_successor(QName, Next).
+
+%% RFC 4471 §3.1.2 step 3, and the regression for the production crash: at the 255-octet ceiling
+%% nothing can be appended, so the right-most octet below 0xff is incremented in place. The label
+%% lengths are the shape that crashed -- nine labels landing exactly on the ceiling -- built from
+%% synthetic content.
+next_dname_increments_leftmost_label_at_255(_Config) ->
+    [Leftmost | Rest] =
+        Labels = [binary:copy(~"a", Len) || Len <- [40, 13, 60, 16, 34, 9, 63, 7, 3]],
+    QName = dns_domain:join(Labels),
+    ?assertEqual(255, byte_size(dns_domain:to_wire(QName))),
+    Next = next_dname(QName),
+    Incremented = <<(binary:part(Leftmost, 0, 39))/binary, $b>>,
+    ?assertEqual([Incremented | Rest], dns_domain:split(Next)),
+    assert_valid_successor(QName, Next).
+
+%% RFC 4471 §3.1.2 step 3 skips uppercase US-ASCII: canonical order compares names lowercased
+%% (RFC 4034 §6.1), so 0x41-0x5a never occur in a canonical name and $@ is followed by $[.
+next_dname_skips_uppercase_ascii(_Config) ->
+    QName = name_of_wire_size(255, ~"trailing@", ~"example.com"),
+    [_ | Rest] = dns_domain:split(QName),
+    Next = next_dname(QName),
+    ?assertEqual([~"trailing[" | Rest], dns_domain:split(Next)),
+    assert_valid_successor(QName, Next).
+
+%% RFC 4471 §3.1.2 step 4: a leftmost label of nothing but 0xff cannot be incremented, so it is
+%% dropped. The successor is then step 2's action on the label beneath it -- `bar\000...', the true
+%% immediate successor -- and not step 3's `bas...', which would claim an empty span over names
+%% such as `barx...' that exist and are representable.
+next_dname_ascends_past_saturated_label(_Config) ->
+    Saturated = binary:copy(<<16#ff>>, 63),
+    QName = name_of_wire_size(255, <<Saturated/binary, ".bar">>, ~"example.com"),
+    [Saturated, ~"bar" | Rest] = dns_domain:split(QName),
+    Next = next_dname(QName),
+    ?assertEqual([~"bar\000" | Rest], dns_domain:split(Next)),
+    assert_valid_successor(QName, Next).
+
+%% End to end: the compact denial-of-existence NSEC for a max-length QNAME is built and signed
+%% instead of raising `name_too_long' out of the RRSIG canonicalisation.
+nsec_signed_for_max_length_qname(_Config) ->
+    ZoneName = dns_domain:to_lower(~"example-dnssec0.com"),
+    QName = name_of_wire_size(255, ~"nonexistent", ZoneName),
+    QLabels = dns_domain:split(QName),
+    QType = ?DNS_TYPE_CNAME,
+    Msg0 = #dns_message{
+        qc = 1,
+        questions = [#dns_query{name = QName, type = QType}],
+        additional = [#dns_optrr{dnssec = true}]
+    },
+    Zone = erldns_zone_cache:get_authoritative_zone(QLabels),
+    #dns_message{authority = Authority} =
+        erldns_dnssec:handle(Msg0, Zone, QLabels, QName, QType, #{}, true),
+    Nsec = lists:keyfind(?DNS_TYPE_NSEC, #dns_rr.type, Authority),
+    ?assertMatch(#dns_rr{name = QName, data = #dns_rrdata_nsec{}}, Nsec),
+    ?assertMatch(
+        #dns_rr{name = QName, data = #dns_rrdata_rrsig{type_covered = ?DNS_TYPE_NSEC}},
+        lists:keyfind(?DNS_TYPE_RRSIG, #dns_rr.type, Authority)
+    ),
+    #dns_rr{data = #dns_rrdata_nsec{next_dname = Next}} = Nsec,
+    assert_valid_successor(QName, Next).
+
+next_dname(QName) ->
+    erldns_dnssec:next_dname(QName, dns_domain:split(QName)).
+
+%% The two invariants every branch of the ladder owes: the successor is encodable at all, which is
+%% what the production crash violated, and it sorts after its input, without which the NSEC would
+%% not deny anything.
+assert_valid_successor(QName, Next) ->
+    ?assert(byte_size(dns_domain:to_wire(Next)) =< 255),
+    ?assert(sorts_before(QName, Next)).
+
+%% Canonical DNS name order (RFC 4034 §6.1) is Erlang term order over the labels reversed: lists
+%% compare element by element, and binaries octet by octet with the shorter of two prefixes first,
+%% which is how labels sort and how a parent sorts before its children. Every name here is already
+%% lowercase, so no canonicalisation is needed first.
+sorts_before(A, B) ->
+    lists:reverse(dns_domain:split(A)) < lists:reverse(dns_domain:split(B)).
+
+%% A name ending in Suffix, with Leftmost as its first label and filler labels in between, whose
+%% wire encoding is exactly Size octets.
+name_of_wire_size(Size, Leftmost, Suffix) ->
+    name_of_wire_size(Size, Leftmost, Suffix, <<>>).
+
+name_of_wire_size(Size, Leftmost, Suffix, Filler) ->
+    Candidate = <<Leftmost/binary, ".", Filler/binary, Suffix/binary>>,
+    case Size - byte_size(dns_domain:to_wire(Candidate)) of
+        0 ->
+            Candidate;
+        Gap when 0 < Gap ->
+            %% Never leave a gap of one, which no label can fill: a label costs its own length
+            %% plus a length octet.
+            Chunk =
+                case 63 < Gap - 1 of
+                    true -> 62;
+                    false -> Gap - 1
+                end,
+            Label = binary:copy(~"a", Chunk),
+            name_of_wire_size(Size, Leftmost, Suffix, <<Filler/binary, Label/binary, ".">>)
+    end.

--- a/test/pipeline_SUITE.erl
+++ b/test/pipeline_SUITE.erl
@@ -6,6 +6,7 @@
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("dns_erlang/include/dns.hrl").
 -define(PIPE_ERROR_EVENT, [erldns, pipeline, error]).
+-define(LOG_REPORT, log_report).
 
 -spec all() -> [ct_suite:ct_test_def()].
 all() ->
@@ -116,8 +117,23 @@ init_per_testcase(_, Config) ->
 
 -spec end_per_testcase(ct_suite:ct_testcase(), ct_suite:ct_config()) -> term().
 end_per_testcase(TC, Config) ->
+    _ = logger:remove_handler(TC),
     erldns_pipeline:delete_pipeline(TC),
     Config.
+
+%% Forward structured reports to this process so a case can assert on what a pipeline failure
+%% actually logs. Keyed by case name, as the pipelines are: `pipe_calls' is a parallel group, so a
+%% shared key would let a sibling's `end_per_testcase/2' tear this down mid-case.
+capture_log_reports(Case) ->
+    _ = logger:remove_handler(Case),
+    logger:add_handler(Case, ?MODULE, #{config => #{pid => self()}}).
+
+%% `logger_handler' callback for `capture_log_reports/0'.
+log(#{msg := {report, #{what := _} = Report}}, #{config := #{pid := Pid}}) ->
+    Pid ! {?LOG_REPORT, Report},
+    ok;
+log(_, _) ->
+    ok.
 
 %% Tests
 terminate_removes_pt(_) ->
@@ -256,6 +272,7 @@ pipe_returns_unexpected_value(_) ->
     assert_telemetry_event(unexpected).
 
 pipe_raises(_) ->
+    ok = capture_log_reports(?FUNCTION_NAME),
     Msg = example_msg(),
     Fun = fun(_, _) -> erlang:error(an_error) end,
     erldns_pipeline:store_pipeline(?FUNCTION_NAME, [Fun]),
@@ -263,7 +280,8 @@ pipe_raises(_) ->
     ?assertMatch(
         #dns_message{tc = false}, erldns_pipeline:call_custom(Msg, def_opts(), ?FUNCTION_NAME)
     ),
-    assert_telemetry_event(exception).
+    assert_telemetry_event(exception),
+    assert_log_report(pipe_failed_with_exception).
 
 simple_prerequisite_satisfied(_) ->
     % Create two mock modules: B depends on A (via callback)
@@ -404,6 +422,17 @@ assert_telemetry_event(Type) ->
             ok
     after 1000 ->
         ct:fail("Telemetry event not triggered: error")
+    end.
+
+%% The report has to carry `reason', not `error'. Downstream error reporters match structured logs
+%% on #{class, reason, stacktrace} and silently drop whatever does not fit, so a rename here costs
+%% the visibility these two logs exist to provide.
+assert_log_report(What) ->
+    receive
+        {?LOG_REPORT, #{what := What, class := _, reason := _, stacktrace := [_ | _]}} ->
+            ok
+    after 1000 ->
+        ct:fail("No log report carrying an exception shape for ~p", [What])
     end.
 
 def_opts() ->


### PR DESCRIPTION
Compact denial of existence builds the NSEC Next Domain Name by prepending a label of one zero octet to the QNAME (RFC 9824 §3.1). That costs two octets on the wire, which a QNAME already sitting at the 255-octet maximum cannot afford, so `dns_domain:to_wire/1` raised `name_too_long` while the synthesized NSEC was being canonicalised for its RRSIG.

Observed in production: https://app.datadoghq.com/logs?query=service%3Aerldnsimple%20%40what%3Apipe_failed_with_exception&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40what%2C%40reason&event=AwAAAZ-tDrLB14qdvAAAABhBWi10RHNRcEFBRHNRTUtEdkVucFVnQUEAAAAkMDE5ZmFkMTMtNzEyZS00OTI3LWFmMzEtNTg0OTE4MmEwZTc4AAF6KQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1785292156911&to_ts=1785306556911&live=true

`erldns_pipeline` caught the exception and carried on with the message untouched, so the server did not fall over — but the response went out as a bare NXDOMAIN plus SOA, with no NSEC, no RRSIG and no AD bit. A validating resolver that asked with DO=1 against a signed zone and received an unsigned negative answer treats it as bogus, so every such query became a SERVFAIL for the end user.

## :mag: QA

N/A

## :clipboard: Deployment Pre/Post tasks

N/A

## :shipit: Deployment Verification

- [ ] No `what=pipe_failed_with_exception` carrying `error=name_too_long` from `erldns_dnssec` in the logs after rollout.
- [ ] The `[erldns, pipeline, error]` telemetry counter returns to its pre-incident baseline.
- [ ] A max-length probe against a signed zone with DO=1 answers NOERROR carrying an NSEC and its RRSIG, and validates (`delv`, or `dig +sigchase`).
- [ ] SERVFAIL rates for signed zones are unchanged or improved.
