### PR TITLE
Expose erldns:stop_listeners/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v11.2.0
+
+### Added
+
+- `erldns:stop_listeners/0` closes the listener sockets on request, the mirror of `erldns:start_listeners/0`.
+
 ## v11.1.1
 
 ### Fixed

--- a/src/erldns.erl
+++ b/src/erldns.erl
@@ -19,7 +19,7 @@ Convenience API to start erldns directly.
 
 -include("erldns.hrl").
 
--export([start/0, start_listeners/0]).
+-export([start/0, start_listeners/0, stop_listeners/0]).
 
 -export_type([keyset/0, zone/0]).
 
@@ -36,7 +36,7 @@ Start the DNS listeners if they were not started at boot.
 When `erldns` is configured with the `autostart_listeners` application environment set to
 `false`, the listeners (and the sockets they bind) are not started during boot. An embedding
 application can then call this once its own resources are ready, so no query is served before
-they exist.
+they exist. Also brings the listeners back after `stop_listeners/0`.
 
 Returns the supervisor child start result. Idempotent: returns `{error, {already_started, _}}`
 when the listeners are already running.
@@ -44,3 +44,17 @@ when the listeners are already running.
 -spec start_listeners() -> supervisor:startchild_ret().
 start_listeners() ->
     erldns_sup:start_listeners().
+
+-doc """
+Stop the DNS listeners, closing the sockets they bind.
+
+The mirror of `start_listeners/0`: an embedding application can call this before tearing down
+the resources its pipeline stages depend on, so no query is served once they are gone. Queries
+in flight are terminated along with the listeners, they are not drained.
+
+Returns `{error, not_found}` when the listeners were never started. Idempotent: returns `ok`
+when they are already stopped.
+""".
+-spec stop_listeners() -> ok | {error, not_found}.
+stop_listeners() ->
+    erldns_sup:stop_listeners().

--- a/src/erldns_sup.erl
+++ b/src/erldns_sup.erl
@@ -17,7 +17,7 @@
 
 -behaviour(supervisor).
 
--export([start_link/0, start_listeners/0]).
+-export([start_link/0, start_listeners/0, stop_listeners/0]).
 -export([gc/0, gc_registered/0, gc_registered/1]).
 
 -export([init/1]).
@@ -27,10 +27,21 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, noargs).
 
 %% Start the DNS listeners on request, for when they were not started at boot
-%% (`autostart_listeners` set to `false`).
+%% (`autostart_listeners` set to `false`), or after `stop_listeners/0`, which keeps the child
+%% spec and therefore makes `supervisor:start_child/2` report `already_present`.
 -spec start_listeners() -> supervisor:startchild_ret().
 start_listeners() ->
-    supervisor:start_child(?MODULE, supervisor(erldns_listeners)).
+    case supervisor:start_child(?MODULE, supervisor(erldns_listeners)) of
+        {error, already_present} ->
+            supervisor:restart_child(?MODULE, erldns_listeners);
+        Result ->
+            Result
+    end.
+
+%% Stop the DNS listeners on request, closing the sockets they bind.
+-spec stop_listeners() -> ok | {error, not_found}.
+stop_listeners() ->
+    supervisor:terminate_child(?MODULE, erldns_listeners).
 
 %% Garbage collect all processes.
 -spec gc() -> integer().

--- a/test/listeners_SUITE.erl
+++ b/test/listeners_SUITE.erl
@@ -23,7 +23,8 @@ all() ->
         reset_queues,
         stats,
         autostart_listeners_gates_init,
-        autostart_listeners_started_on_request
+        autostart_listeners_started_on_request,
+        listeners_stopped_on_request
     ].
 
 -spec groups() -> [ct_suite:ct_group_def()].
@@ -157,6 +158,31 @@ autostart_listeners_started_on_request(Config) ->
     ?assertMatch({ok, _}, erpc:call(Node, erldns, start_listeners, [])),
     ?assert(is_pid(erpc:call(Node, erlang, whereis, [erldns_listeners]))),
     ?assertMatch({error, {already_started, _}}, erpc:call(Node, erldns, start_listeners, [])),
+    app_helper:stop(Config1).
+
+listeners_stopped_on_request(Config) ->
+    % stop_listeners/0 closes the listeners started at boot and is idempotent; the child spec is
+    % kept, so start_listeners/0 opens them again.
+    AppConfig = [
+        {erldns, [
+            {listeners, [
+                #{
+                    name => ?FUNCTION_NAME,
+                    transport => standard,
+                    port => 0,
+                    opts => #{ingress_request_timeout => ?INGRESS_TIMEOUT}
+                }
+            ]}
+        ]}
+    ],
+    Config1 = app_helper:start_per_testcase(Config, AppConfig),
+    Node = app_helper:get_node(Config1),
+    ?assert(is_pid(erpc:call(Node, erlang, whereis, [erldns_listeners]))),
+    ?assertEqual(ok, erpc:call(Node, erldns, stop_listeners, [])),
+    ?assertEqual(undefined, erpc:call(Node, erlang, whereis, [erldns_listeners])),
+    ?assertEqual(ok, erpc:call(Node, erldns, stop_listeners, [])),
+    ?assertMatch({ok, _}, erpc:call(Node, erldns, start_listeners, [])),
+    ?assert(is_pid(erpc:call(Node, erlang, whereis, [erldns_listeners]))),
     app_helper:stop(Config1).
 
 port_must_be_inet_port(_) ->


### PR DESCRIPTION
The mirror of start_listeners/0: an embedding application that defers the listeners at boot (autostart_listeners=false) until its own resources are up has no way to close them again before those resources are torn down, so a query served during shutdown can reach a pipeline stage whose ETS tables have already died with their owner.

## :mag: QA

N/A

## :clipboard: Deployment Pre/Post tasks

N/A

## :shipit: Deployment Verification

N/A