### PR TITLE
Reach the custom decoders without raising through dns_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+### Changed
+
+- A zone half made of custom types decodes ~70x faster, one almost entirely made of them ~200x; zones of standard types are unaffected.
+
 ## v11.2.0
 
 ### Added

--- a/src/zones/erldns_zone_decoder.erl
+++ b/src/zones/erldns_zone_decoder.erl
@@ -9,6 +9,8 @@
 
 -export([decode/2, decode_record/2, parse_keysets/1]).
 
+-type context_options() :: undefined | #{atom() => dynamic()}.
+
 -ifdef(TEST).
 -export([json_record_to_erlang/1]).
 -endif.
@@ -17,7 +19,10 @@
 decode(#{~"name" := Name, ~"records" := JsonRecords} = Zone, Decoders) ->
     Sha = maps:get(~"sha", Zone, ~""),
     JsonKeys = maps:get(~"keys", Zone, []),
-    Records = lists:map(fun(JsonRecord) -> decode_record(JsonRecord, Decoders) end, JsonRecords),
+    ContextOptions = context_options(),
+    Records = lists:map(
+        fun(JsonRecord) -> decode_record(JsonRecord, Decoders, ContextOptions) end, JsonRecords
+    ),
     FilteredRecords = lists:filter(record_filter(), Records),
     DistinctRecords = lists:usort(FilteredRecords),
     erldns_zone_codec:build_zone(Name, Sha, DistinctRecords, parse_keysets(JsonKeys)).
@@ -25,9 +30,16 @@ decode(#{~"name" := Name, ~"records" := JsonRecords} = Zone, Decoders) ->
 -spec decode_record(#{binary() => json:decode_value()}, [erldns_zone_codec:decoder()]) ->
     not_implemented | dns:rr().
 decode_record(JsonRecord, Decoders) ->
+    decode_record(JsonRecord, Decoders, context_options()).
+
+-spec decode_record(
+    #{binary() => json:decode_value()}, [erldns_zone_codec:decoder()], context_options()
+) ->
+    not_implemented | dns:rr().
+decode_record(JsonRecord, Decoders, ContextOptions) ->
     maybe
-        true ?= apply_context_options(JsonRecord),
-        not_implemented ?= json_record_to_erlang(JsonRecord),
+        true ?= apply_context_options(JsonRecord, ContextOptions),
+        not_implemented ?= standard_record_to_erlang(JsonRecord),
         not_implemented ?= try_custom_decoders(JsonRecord, Decoders),
         ?LOG_WARNING(#{what => unsupported_record, record => JsonRecord}, ?LOG_METADATA),
         not_implemented
@@ -37,6 +49,32 @@ decode_record(JsonRecord, Decoders) ->
         Value ->
             Value
     end.
+
+-spec standard_record_to_erlang(dynamic()) -> not_implemented | dns:rr().
+standard_record_to_erlang(#{~"type" := TypeBin} = JsonRecord) when
+    is_binary(TypeBin), ~"" =/= TypeBin
+->
+    case dns_names:name_type(TypeBin) of
+        undefined ->
+            case all_digits(TypeBin) of
+                true -> json_record_to_erlang(JsonRecord);
+                false -> not_implemented
+            end;
+        _KnownType ->
+            json_record_to_erlang(JsonRecord)
+    end;
+standard_record_to_erlang(_JsonRecord) ->
+    not_implemented.
+
+%% Matched on bytes rather than through `string:to_integer/1',
+%% which walks the binary as unicode graphemes.
+-spec all_digits(binary()) -> boolean().
+all_digits(<<C, Rest/binary>>) when $0 =< C, C =< $9 ->
+    all_digits(Rest);
+all_digits(~"") ->
+    true;
+all_digits(_) ->
+    false.
 
 -spec parse_keysets([json:decode_value()]) -> [erldns:keyset()].
 parse_keysets([]) ->
@@ -93,21 +131,29 @@ record_filter() ->
 %%
 %% If the context is a list and has at least one condition that passes
 %% then it will be included in the zone
--spec apply_context_options(dynamic()) -> boolean().
-apply_context_options(#{~"context" := Context}) ->
+-spec apply_context_options(dynamic(), context_options()) -> boolean().
+apply_context_options(_JsonRecord, undefined) ->
+    true;
+apply_context_options(#{~"context" := Context}, ContextOptions) ->
+    apply_context_match_empty_check(
+        maps:get(match_empty, ContextOptions, false), Context
+    ) orelse
+        apply_context_list_check(
+            maps:get(allow, ContextOptions, []), Context
+        );
+apply_context_options(#{}, _ContextOptions) ->
+    true.
+
+%% Read once per zone rather than per record: it is an ETS lookup into the application
+%% controller, and a zone holds as many records as it holds.
+-spec context_options() -> context_options().
+context_options() ->
     case application:get_env(erldns, zones, #{}) of
         #{context_options := ContextOptions} when is_map(ContextOptions) ->
-            apply_context_match_empty_check(
-                maps:get(match_empty, ContextOptions, false), Context
-            ) orelse
-                apply_context_list_check(
-                    maps:get(allow, ContextOptions, []), Context
-                );
+            ContextOptions;
         _ ->
-            true
-    end;
-apply_context_options(#{}) ->
-    true.
+            undefined
+    end.
 
 -spec apply_context_list_check(list(), list()) -> boolean().
 apply_context_list_check(ContextAllow, Context) ->
@@ -132,7 +178,7 @@ try_custom_decoders(Data, [Decoder | Rest]) ->
     end.
 
 % Internal converters
--spec json_record_to_erlang(dynamic()) -> not_implemented | dns:rr() | badarg.
+-spec json_record_to_erlang(dynamic()) -> not_implemented | dns:rr().
 json_record_to_erlang(#{~"name" := _, ~"type" := _, ~"ttl" := _, ~"data" := Data} = JsonRecord) when
     Data =/= null
 ->

--- a/test/zones_SUITE.erl
+++ b/test/zones_SUITE.erl
@@ -85,6 +85,9 @@ groups() ->
             json_record_svcb_keynnnn_format,
             json_record_null_data,
             json_record_unsupported_type,
+            json_record_numeric_type,
+            json_record_unknown_type_reaches_custom_decoders,
+            json_record_without_type_name_reaches_custom_decoders,
             encode_meta_to_json,
             encode_decode_svcb,
             encode_decode_https,
@@ -1057,6 +1060,79 @@ json_record_unsupported_type(_) ->
             },
             []
         )
+    ).
+
+json_record_numeric_type(_) ->
+    %% A bare numeric type name is a standard record, not a custom one, and must still be
+    %% decoded rather than handed to the custom decoders.
+    ?assertEqual(
+        #dns_rr{
+            name = ~"example.com",
+            type = ?DNS_TYPE_A,
+            data = #dns_rrdata_a{ip = {192, 0, 2, 1}},
+            ttl = 3600
+        },
+        erldns_zone_decoder:decode_record(
+            #{
+                ~"name" => ~"example.com",
+                ~"type" => integer_to_binary(?DNS_TYPE_A),
+                ~"ttl" => 3600,
+                ~"data" => #{~"ip" => ~"192.0.2.1"}
+            },
+            []
+        )
+    ).
+
+json_record_unknown_type_reaches_custom_decoders(_) ->
+    %% A type name dns_erlang does not know belongs to a custom decoder. It is reached
+    %% without dns_json raising on the way, which is what makes a zone of such records
+    %% decode in the same time as a zone of standard ones.
+    %% `TYPE65535' is here because it looks decodable and is not: `dns_names:name_type/1'
+    %% has no clause for RFC 3597's generic spelling and `string:to_integer/1' does not
+    %% strip the prefix, so dns_json rejects it too and it belongs to the custom decoders.
+    Decoder = fun
+        (#{~"type" := Type, ~"name" := Name, ~"ttl" := Ttl}) when
+            Type =:= ~"CUSTOM"; Type =:= ~"TYPE65535"
+        ->
+            #dns_rr{name = Name, type = 30001, ttl = Ttl, data = ~"custom"};
+        (_) ->
+            not_implemented
+    end,
+    lists:foreach(
+        fun(Type) ->
+            ?assertEqual(
+                #dns_rr{name = ~"example.com", type = 30001, ttl = 3600, data = ~"custom"},
+                erldns_zone_decoder:decode_record(
+                    #{
+                        ~"name" => ~"example.com",
+                        ~"type" => Type,
+                        ~"ttl" => 3600,
+                        ~"data" => #{}
+                    },
+                    [Decoder]
+                )
+            )
+        end,
+        [~"CUSTOM", ~"TYPE65535"]
+    ).
+
+json_record_without_type_name_reaches_custom_decoders(_) ->
+    %% `dns_json:from_map/1' guards its record clause on a binary type, so a record without
+    %% one is not a standard record by construction: missing, empty and non-binary alike
+    %% belong to the custom decoders, and are left unread when there are none.
+    Decoder = fun(#{~"name" := Name, ~"ttl" := Ttl}) ->
+        #dns_rr{name = Name, type = 30001, ttl = Ttl, data = ~"custom"}
+    end,
+    Untyped = #{~"name" => ~"example.com", ~"ttl" => 3600, ~"data" => #{}},
+    lists:foreach(
+        fun(JsonRecord) ->
+            ?assertEqual(
+                #dns_rr{name = ~"example.com", type = 30001, ttl = 3600, data = ~"custom"},
+                erldns_zone_decoder:decode_record(JsonRecord, [Decoder])
+            ),
+            ?assertEqual(not_implemented, erldns_zone_decoder:decode_record(JsonRecord, []))
+        end,
+        [Untyped, Untyped#{~"type" => ~""}, Untyped#{~"type" => ?DNS_TYPE_A}]
     ).
 
 json_record_context_filtered(_) ->


### PR DESCRIPTION
Zone decoding spent most of its time discovering that a record was not standard. `dns_json` signals an unknown type name by raising, and the decoder caught that to fall through to the custom decoders — so every ALIAS, URL and POOL record cost a failed name lookup, a `string:to_integer/1` walk over a non-numeric binary, an exception with stacktrace capture, and a discarded debug log, before the decoder that handles it ever ran.

- The type name is checked first: anything `dns_names` does not know and that is not a bare number goes straight to the custom decoders. Malformed records still raise as before.
- A record without a binary type name is not a standard record by construction — `dns_json:from_map/1` guards on one — so it skips the standard path entirely.
- `context_options` is read once per zone instead of once per record.

Decoding 50k records, median of 7: unchanged at 0% custom records (19.1ms → 17.5ms), **70× faster at 50%** (964.7ms → 13.8ms), **235× faster at 95%** (1,848.5ms → 7.9ms). Cost was linear at ~38µs per custom record, so it scaled with how custom a zone was, not how big. Found while profiling a production node whose zone fetcher pool was 68% of all node reductions.

No behaviour change: every record that decoded before decodes the same way, and every record that reached a custom decoder still does.

## :mag: QA

**Scenario: custom record types still decode**

- Load a zone containing ALIAS, URL and POOL records and confirm each resolves as before.
- Load a zone with a numeric type name (`"type": "65535"`) and confirm it still decodes as a standard record rather than falling through to the custom decoders.

## :clipboard: Deployment Pre/Post tasks

N/A

## :shipit: Deployment Verification

- [ ] After `erldnsimple` picks up this version, confirm the zone fetcher pool's share of node reductions drops from ~68% (`:recon.proc_window(:reductions, 10, 5_000)`).